### PR TITLE
Use locally built RecyclerViewPager lib in demo

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile project(':lib')
     compile 'com.android.support:appcompat-v7:22.2.0'
-    compile('com.lsjwzh:recyclerviewpager:1.0.7-SNAPSHOT')
 }


### PR DESCRIPTION
Using the published version of RecyclerViewPager makes it harder to develop. If we use the locally built one instead, we can make changes to the lib and examine those in the demo app.