### PR TITLE
Set mPositionBeforeScroll to page we notify switched to

### DIFF
--- a/lib/src/main/java/com/lsjwzh/widget/recyclerviewpager/RecyclerViewPager.java
+++ b/lib/src/main/java/com/lsjwzh/widget/recyclerviewpager/RecyclerViewPager.java
@@ -335,6 +335,7 @@ public class RecyclerViewPager extends RecyclerView {
                         }
                     }
                 }
+                mPositionBeforeScroll = mSmoothScrollTargetPosition;
             }
             // reset
             mMaxLeftWhenDragging = Integer.MIN_VALUE;


### PR DESCRIPTION
This resolves issue #33 and it makes sense: when we publish the on page change notification to a new page, set our internal position before scroll (`mPositionBeforeScroll`) to the new position. This ensures we keep `mPositionBeforeScroll` up to date.