### PR TITLE
Fix: the most recent ViewPager could work correctly with scrolling direction "MATH_PARENT".

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ repositories {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.lsjwzh.widget.recyclerviewpagerdeomo"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion '23.0.3'
     defaultConfig {
         minSdkVersion 7
         targetSdkVersion 22
@@ -25,5 +25,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:recyclerview-v7:22.2.1'
+    compile 'com.android.support:recyclerview-v7:23.2.1'
 }

--- a/lib/src/main/java/com/lsjwzh/widget/recyclerviewpager/RecyclerViewPagerAdapter.java
+++ b/lib/src/main/java/com/lsjwzh/widget/recyclerviewpager/RecyclerViewPagerAdapter.java
@@ -77,11 +77,16 @@ public class RecyclerViewPagerAdapter<VH extends RecyclerView.ViewHolder> extend
     public void onBindViewHolder(VH holder, int position) {
         mAdapter.onBindViewHolder(holder, position);
         final View itemView = holder.itemView;
-        ViewGroup.LayoutParams lp = itemView.getLayoutParams() == null ? new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT) : itemView.getLayoutParams();
-        if (mViewPager.getLayoutManager().canScrollHorizontally()) {
-            lp.width = mViewPager.getMeasuredWidth() - mViewPager.getPaddingLeft() - mViewPager.getPaddingRight();
+        ViewGroup.LayoutParams lp;
+        if (itemView.getLayoutParams() == null) {
+            lp = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
         } else {
-            lp.height = mViewPager.getMeasuredHeight() - mViewPager.getPaddingTop() - mViewPager.getPaddingBottom();
+            lp = itemView.getLayoutParams();
+            if (mViewPager.getLayoutManager().canScrollHorizontally()) {
+                lp.width = ViewGroup.LayoutParams.MATCH_PARENT;
+            } else {
+                lp.height = ViewGroup.LayoutParams.MATCH_PARENT;
+            }
         }
         itemView.setLayoutParams(lp);
     }


### PR DESCRIPTION
So we don't need to calculate exact width/height anymore. 