### PR TITLE
Fixes #102 - Don't spam syserr when using a holder without mPosition field

### DIFF
--- a/lib/src/main/java/com/lsjwzh/widget/recyclerviewpager/LoopRecyclerViewPagerAdapter.java
+++ b/lib/src/main/java/com/lsjwzh/widget/recyclerviewpager/LoopRecyclerViewPagerAdapter.java
@@ -1,11 +1,14 @@
 package com.lsjwzh.widget.recyclerviewpager;
 
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 
 import java.lang.reflect.Field;
 
 public class LoopRecyclerViewPagerAdapter<VH extends RecyclerView.ViewHolder>
         extends RecyclerViewPagerAdapter<VH> {
+
+    private static final String TAG = LoopRecyclerViewPager.class.getSimpleName();
 
     private Field mPositionField;
 
@@ -44,19 +47,21 @@ public class LoopRecyclerViewPagerAdapter<VH extends RecyclerView.ViewHolder>
     public void onBindViewHolder(VH holder, int position) {
         super.onBindViewHolder(holder, getActualPosition(position));
         // because of getCurrentPosition may return ViewHolder‘s position,
-        // so we must reset mPosition.
+        // so we must reset mPosition if exists.
         if (mPositionField == null) {
             try {
                 mPositionField = holder.getClass().getDeclaredField("mPosition");
                 mPositionField.setAccessible(true);
             } catch (NoSuchFieldException e) {
-                e.printStackTrace();
+                Log.i(TAG, "The holder doesn't have a mPosition field.");
             }
         }
-        try {
-            mPositionField.set(holder, position);
-        } catch (Exception e) {
-            e.printStackTrace();
+        if (mPositionField != null) {
+            try {
+                mPositionField.set(holder, position);
+            } catch (Exception e) {
+                Log.w(TAG, "Error while updating holder's mPosition field", e);
+            }
         }
     }
 


### PR DESCRIPTION
Please note this way to use a private field is still a bad practice. At least with this patch it doesn't spam logs.