### PR TITLE
Fix: onPageChanged is sometimes not fired.

### DIFF
--- a/lib/src/main/java/com/lsjwzh/widget/recyclerviewpager/RecyclerViewPager.java
+++ b/lib/src/main/java/com/lsjwzh/widget/recyclerviewpager/RecyclerViewPager.java
@@ -174,7 +174,10 @@ public class RecyclerViewPager extends RecyclerView {
         if (DEBUG) {
             Log.d("@", "smoothScrollToPosition:" + position);
         }
-        mPositionBeforeScroll = getCurrentPosition();
+
+        if (mPositionBeforeScroll < 0) {
+            mPositionBeforeScroll = getCurrentPosition();
+        }
         mSmoothScrollTargetPosition = position;
         if (getLayoutManager() != null && getLayoutManager() instanceof LinearLayoutManager) {
             // exclude item decoration


### PR DESCRIPTION
`OnPageChangedListener#onPageChanged` is sometimes not called on RecyclerViewPager flung.

To reproduce this issue, please fling RecyclerViewPager slowly. Then onPageChanged will not be probably called.
mPositionBeforeScroll has been updated by currentPosition while flinging RecyclerViewPager.