### PR TITLE
List item doesn't take entire screen. Delimiter added.

### DIFF
--- a/app/src/main/java/com/lsjwzh/widget/recyclerviewpagerdeomo/MainActivity.java
+++ b/app/src/main/java/com/lsjwzh/widget/recyclerviewpagerdeomo/MainActivity.java
@@ -19,6 +19,7 @@ package com.lsjwzh.widget.recyclerviewpagerdeomo;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -42,6 +43,8 @@ public class MainActivity extends AppCompatActivity {
         mDemoRecyclerView = (RecyclerView) findViewById(R.id.demo_list);
         mDemoRecyclerView.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager
                 .VERTICAL, false));
+        mDemoRecyclerView.addItemDecoration(new DividerItemDecoration(this, LinearLayoutManager
+                .VERTICAL));
         mDemoListAdapter = new DemoListAdapter();
         mDemoRecyclerView.setAdapter(mDemoListAdapter);
         mDemoListAdapter.add(new DemoItem("Single Fling Pager(like official ViewPager)") {

--- a/app/src/main/res/layout/demo_list_item.xml
+++ b/app/src/main/res/layout/demo_list_item.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
               android:layout_width="match_parent"
-              android:layout_height="match_parent">
+              android:layout_height="wrap_content">
 
   <TextView
     android:id="@+id/text"


### PR DESCRIPTION
Layout_height property of demo_list_item changed to wrap_content to avoid taking whole screen. 
Delimiter added to main screen list.