### PR TITLE
Api 26.1.0 compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,13 +7,13 @@ repositories {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.lsjwzh.widget.recyclerviewpagerdeomo"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -30,15 +30,15 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':lib')
-    compile project(':tablayoutsupport')
-    compile 'com.android.support:appcompat-v7:26.0.2'
-    compile 'com.android.support:appcompat-v7:26.0.2'
-    compile 'com.android.support:design:26.0.2'
-    compile 'com.android.support:support-v4:26.0.2'
-    compile 'com.android.support:support-v13:26.0.2'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':lib')
+    implementation project(':tablayoutsupport')
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:support-v13:28.0.0'
 
-    compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'de.hdodenhof:circleimageview:1.3.0'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'de.hdodenhof:circleimageview:1.3.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,14 @@
 
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven { url "https://jitpack.io" }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         google()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:3.0.1')
+        classpath('com.android.tools.build:gradle:3.3.0')
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 28
         versionName "1.2.0"
     }
@@ -24,8 +24,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:recyclerview-v7:26.0.2'
-    compile 'com.android.support:appcompat-v7:26.0.2'
-    compile 'com.android.support:support-v4:26.0.2'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
 }

--- a/tablayoutsupport/build.gradle
+++ b/tablayoutsupport/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 2
         versionName "1.2.0"
     }
@@ -19,6 +19,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:design:26.0.2'
-    compile project(':lib')
+    implementation 'com.android.support:design:28.0.0'
+    implementation project(':lib')
 }

--- a/tablayoutsupport/src/main/java/com/lsjwzh/widget/recyclerviewpager/TabLayoutSupport.java
+++ b/tablayoutsupport/src/main/java/com/lsjwzh/widget/recyclerviewpager/TabLayoutSupport.java
@@ -23,7 +23,7 @@ public class TabLayoutSupport {
                 = new TabLayoutOnPageChangeListener(tabLayout, viewPager);
         viewPager.addOnScrollListener(listener);
         viewPager.addOnPageChangedListener(listener);
-        tabLayout.setOnTabSelectedListener(new ViewPagerOnTabSelectedListener(viewPager, listener));
+        tabLayout.addOnTabSelectedListener(new ViewPagerOnTabSelectedListener(viewPager, listener));
     }
 
     public interface ViewPagerTabLayoutAdapter {


### PR DESCRIPTION
- Starting with API 26.1.0, TabLayout$setOnTabSelectedListener() is deprecated in favor of addOnTabSelectedListener. This leads to the TabLayoutSupport to crash the app when using said API level. This fix removes the deprecated method in favor of the new one.
- Updated the build tools version and compile sdk version to API level 28 as well as the gradle plugin versions for compatibility with Android Studio 3.3.
- Updated dependency versions